### PR TITLE
fix(sql): remove call to .read_all()on table

### DIFF
--- a/influxdb_cli/influx3.py
+++ b/influxdb_cli/influx3.py
@@ -39,8 +39,7 @@ class IOXCLI(cmd.Cmd):
             print("can't query, no active configs")
             return
         try: 
-            reader = self.influxdb_client.query(query=arg, language="sql")
-            table = reader.read_all()
+            table = self.influxdb_client.query(query=arg, language="sql")
             print(table.to_pandas().to_markdown())
         except Exception as e:
             print(e)


### PR DESCRIPTION
This commit removes the call to `.read_all` (intended for the formerly returned `reader`) on the returned table.

- influxdb3-python do_sql() already calls .read_all() on the reader and returns the table.
- The CLI calling .read_all() again on the table throws a no method error.
